### PR TITLE
Remove Controller From States + Maintain Internal Event Dispatches

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ It breaks the HSM into these notable components:
 1. State Controller trait: [HsmController]
 2. Concrete Controller implementing [HsmController]: [HSMControllerBase](./rust_hsm/src/state_controller.rs)
    1. Notably there is very little inside the concrete controller, by design!
-   2. If you would like to implement a thread safe controller, copy `HSMControllerBase` and implement a different `external_dispatch_into_hsm`!
+   2. If you would like to implement a thread safe controller, copy `HSMControllerBase` and implement a different `dispatch_event`!
 3. States which implement the [StateChainOfResponsibility] trait
    1. Handles flow into / out of a given state
    2. Allows implementers to delegate the handling of their custom enum events within the `handle_event` impl.

--- a/example_hsm/src/light_hsm/light_events.rs
+++ b/example_hsm/src/light_hsm/light_events.rs
@@ -54,7 +54,7 @@ impl std::fmt::Display for LightEvents {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
             Self::Toggle => write!(f, "Toggle"),
-            Self::Set(value) => write!(f, "Set({value})", ),
+            Self::Set(value) => write!(f, "Set({value})",),
             Self::TurnOff => write!(f, "TurnOff"),
             Self::TurnOn => write!(f, "TurnOn"),
             Self::ReduceByPercent(value) => write!(f, "ReduceByPercent({value}%)"),

--- a/example_hsm/src/light_hsm/light_hsm_controller.rs
+++ b/example_hsm/src/light_hsm/light_hsm_controller.rs
@@ -31,28 +31,16 @@ impl LightControllerHsm {
             _shared_data: shared_data.clone(),
         }));
 
-        let top_state = LightStateTop::new(light_hsm.borrow().get_hsm());
+        let top_state = LightStateTop::new();
 
         // Both on and off leverage similar behavior to dimmer in most cases!
         // the non-shared behavior they impl for themselves!
         // Hence dimmer is their parent.
-        let state_dimmer = LightStateDimmer::new(
-            top_state.clone(),
-            light_hsm.borrow().get_hsm(),
-            shared_data.clone(),
-        );
+        let state_dimmer = LightStateDimmer::new(top_state.clone(), shared_data.clone());
 
-        let state_on = LightStateOn::new(
-            state_dimmer.clone(),
-            light_hsm.borrow().get_hsm(),
-            shared_data.clone(),
-        );
+        let state_on = LightStateOn::new(state_dimmer.clone(), shared_data.clone());
 
-        let state_off = LightStateOff::new(
-            state_dimmer.clone(),
-            light_hsm.borrow().get_hsm(),
-            shared_data.clone(),
-        );
+        let state_off = LightStateOff::new(state_dimmer.clone(), shared_data.clone());
 
         light_hsm.borrow_mut().add_state(top_state);
         light_hsm.borrow_mut().add_state(state_on);

--- a/example_hsm/src/light_hsm/light_hsm_controller.rs
+++ b/example_hsm/src/light_hsm/light_hsm_controller.rs
@@ -25,45 +25,32 @@ impl LightControllerHsm {
 
         // Start the light "off"
         let shared_data = LightHsmData::new(0);
-
-        let light_hsm = Rc::new(RefCell::new(LightControllerHsm {
-            hsm,
-            _shared_data: shared_data.clone(),
-        }));
-
+        
         let top_state = LightStateTop::new();
 
         // Both on and off leverage similar behavior to dimmer in most cases!
         // the non-shared behavior they impl for themselves!
         // Hence dimmer is their parent.
         let state_dimmer = LightStateDimmer::new(top_state.clone(), shared_data.clone());
-
         let state_on = LightStateOn::new(state_dimmer.clone(), shared_data.clone());
-
         let state_off = LightStateOff::new(state_dimmer.clone(), shared_data.clone());
 
-        light_hsm.borrow_mut().add_state(top_state);
-        light_hsm.borrow_mut().add_state(state_on);
-        light_hsm.borrow_mut().add_state(state_off.clone());
-        light_hsm.borrow_mut().add_state(state_dimmer);
+        hsm.borrow_mut().add_state(top_state);
+        hsm.borrow_mut().add_state(state_on);
+        hsm.borrow_mut().add_state(state_off.clone());
+        hsm.borrow_mut().add_state(state_dimmer);
+        hsm.borrow_mut().init(state_off).unwrap();
 
-        // Start with the lights off
-        light_hsm.borrow_mut().init(state_off.clone());
+        let light_hsm = Rc::new(RefCell::new(LightControllerHsm {
+            hsm,
+            _shared_data: shared_data.clone(),
+        }));
 
         light_hsm
     }
 
     pub fn get_hsm(&self) -> HsmControllerRef {
         self.hsm.clone()
-    }
-
-    pub fn add_state(&mut self, new_state: StateRef) {
-        self.hsm.borrow_mut().add_state(new_state)
-    }
-
-    /// Note: exposing init like this is discouraged, but can be done!
-    pub fn init(&mut self, starting_state: StateRef) {
-        let _ = self.hsm.borrow_mut().init(starting_state);
     }
 
     /// Note: exposing the current state is ALSO a really bad idea.

--- a/example_hsm/src/light_hsm/light_hsm_data.rs
+++ b/example_hsm/src/light_hsm/light_hsm_data.rs
@@ -12,7 +12,7 @@ pub enum LightAdjustment {
 pub struct LightHsmData {
     /// 0 = off, 100 = on
     /// Again...leaking this is a bad idea. It is only done here for testing/asserting
-    pub (crate) light_percentage: u8,
+    pub(crate) light_percentage: u8,
 }
 
 impl LightHsmData {

--- a/example_hsm/src/light_hsm/light_state_dimmer.rs
+++ b/example_hsm/src/light_hsm/light_state_dimmer.rs
@@ -30,6 +30,11 @@ impl LightStateDimmer {
     }
 
     fn set_to_percentage(&mut self, percentage: u8) -> bool {
+        if percentage == 0 {
+            self.dispatch_internally(Rc::new(LightEvents::TurnOff));
+        } else if percentage >= 100 {
+            self.dispatch_internally(Rc::new(LightEvents::TurnOn));
+        }
         self.shared_data.borrow_mut().set_lighting(percentage)
     }
 
@@ -53,6 +58,8 @@ impl StateChainOfResponsibility for LightStateDimmer {
             LightEvents::IncreaseByPercent(percentage) => {
                 self.set_relative(LightAdjustment::Increase, percentage)
             }
+            // TurnOff and Toggle are implemented by our parent (LightStateOn)
+            // Leverage that behavior by not handling them
             _ => false,
         }
     }

--- a/example_hsm/src/light_hsm/light_state_dimmer.rs
+++ b/example_hsm/src/light_hsm/light_state_dimmer.rs
@@ -1,7 +1,6 @@
 use rust_hsm::{
     events::StateEventsIF,
     state::{ComposableStateData, StateChainOfResponsibility, StateRef},
-    state_controller_trait::HsmControllerRef,
 };
 
 use crate::{
@@ -17,16 +16,11 @@ pub(crate) struct LightStateDimmer {
 }
 
 impl LightStateDimmer {
-    pub fn new(
-        parent_state: StateRef,
-        hsm: HsmControllerRef,
-        shared_data: LightHsmDataRef,
-    ) -> Rc<RefCell<Self>> {
+    pub fn new(parent_state: StateRef, shared_data: LightHsmDataRef) -> Rc<RefCell<Self>> {
         let state_data = ComposableStateData::new(
             LightStates::DIMMER as u16,
             "LightStateDimmer".to_string(),
             Some(parent_state),
-            hsm,
         );
 
         Rc::new(RefCell::new(Self {
@@ -67,8 +61,7 @@ impl StateChainOfResponsibility for LightStateDimmer {
         &self.state_data
     }
 
-    fn get_state_data_mut(&mut self) -> &mut ComposableStateData
-    {
+    fn get_state_data_mut(&mut self) -> &mut ComposableStateData {
         &mut self.state_data
     }
 }

--- a/example_hsm/src/light_hsm/light_state_off.rs
+++ b/example_hsm/src/light_hsm/light_state_off.rs
@@ -1,7 +1,6 @@
 use rust_hsm::{
     events::StateEventsIF,
     state::{ComposableStateData, StateChainOfResponsibility, StateRef},
-    state_controller_trait::HsmControllerRef,
 };
 
 use crate::{
@@ -15,16 +14,11 @@ pub(crate) struct LightStateOff {
 }
 
 impl LightStateOff {
-    pub fn new(
-        parent_state: StateRef,
-        hsm: HsmControllerRef,
-        shared_data: LightHsmDataRef,
-    ) -> Rc<RefCell<Self>> {
+    pub fn new(parent_state: StateRef, shared_data: LightHsmDataRef) -> Rc<RefCell<Self>> {
         let state_data = ComposableStateData::new(
             LightStates::OFF as u16,
             "LightStateOff".to_string(),
             Some(parent_state),
-            hsm,
         );
 
         Rc::new(RefCell::new(Self {
@@ -63,8 +57,7 @@ impl StateChainOfResponsibility for LightStateOff {
         &self.state_data
     }
 
-    fn get_state_data_mut(&mut self) -> &mut ComposableStateData
-    {
+    fn get_state_data_mut(&mut self) -> &mut ComposableStateData {
         &mut self.state_data
     }
 }

--- a/example_hsm/src/light_hsm/light_state_on.rs
+++ b/example_hsm/src/light_hsm/light_state_on.rs
@@ -1,7 +1,6 @@
 use rust_hsm::{
     events::StateEventsIF,
     state::{ComposableStateData, StateChainOfResponsibility, StateRef},
-    state_controller_trait::HsmControllerRef,
 };
 
 use crate::{
@@ -15,16 +14,11 @@ pub(crate) struct LightStateOn {
 }
 
 impl LightStateOn {
-    pub fn new(
-        parent_state: StateRef,
-        hsm: HsmControllerRef,
-        shared_data: LightHsmDataRef,
-    ) -> Rc<RefCell<Self>> {
+    pub fn new(parent_state: StateRef, shared_data: LightHsmDataRef) -> Rc<RefCell<Self>> {
         let state_data = ComposableStateData::new(
             LightStates::ON as u16,
             "LightStateOn".to_string(),
             Some(parent_state),
-            hsm,
         );
 
         Rc::new(RefCell::new(Self {
@@ -67,8 +61,7 @@ impl StateChainOfResponsibility for LightStateOn {
         &self.state_data
     }
 
-    fn get_state_data_mut(&mut self) -> &mut ComposableStateData
-    {
+    fn get_state_data_mut(&mut self) -> &mut ComposableStateData {
         &mut self.state_data
     }
 }

--- a/example_hsm/src/light_hsm/light_state_top.rs
+++ b/example_hsm/src/light_hsm/light_state_top.rs
@@ -3,7 +3,6 @@ use std::{cell::RefCell, rc::Rc};
 use rust_hsm::{
     events::StateEventsIF,
     state::{ComposableStateData, StateChainOfResponsibility},
-    state_controller_trait::HsmControllerRef,
 };
 
 use crate::{light_events::LightEvents, light_states::LightStates};
@@ -13,13 +12,9 @@ pub struct LightStateTop {
 }
 
 impl LightStateTop {
-    pub fn new(hsm: HsmControllerRef) -> Rc<RefCell<Self>> {
-        let data = ComposableStateData::new(
-            LightStates::TOP as u16,
-            "LightStateTop".to_string(),
-            None,
-            hsm,
-        );
+    pub fn new() -> Rc<RefCell<Self>> {
+        let data =
+            ComposableStateData::new(LightStates::TOP as u16, "LightStateTop".to_string(), None);
 
         Rc::new(RefCell::new(Self { state_data: data }))
     }
@@ -38,8 +33,7 @@ impl StateChainOfResponsibility for LightStateTop {
         &self.state_data
     }
 
-    fn get_state_data_mut(&mut self) -> &mut ComposableStateData
-    {
+    fn get_state_data_mut(&mut self) -> &mut ComposableStateData {
         &mut self.state_data
     }
 }

--- a/example_hsm/src/main.rs
+++ b/example_hsm/src/main.rs
@@ -9,42 +9,14 @@ fn main() {
     let mut light_hsm = LightControllerHsm::new();
 
     let starting_state = light_hsm.get_current_state();
-    assert!(starting_state.borrow().get_state_id().get_id().clone() == LightStates::OFF as u16);
+    assert!(starting_state.borrow().get_state_id().get_id().clone() == LightStates::DIMMER as u16);
 
+    // Set the dimmer value that triggers another internal event being fired for OFF
     {
-        light_hsm.dispatch_into_hsm(LightEvents::TurnOn);
-
+        light_hsm.dispatch_into_hsm(LightEvents::Set(0));
         let state = light_hsm.get_current_state();
         let state_id = state.borrow().get_state_id();
-        let expected_state_id = StateId::new(LightStates::ON as u16);
-
-        assert!(
-            state_id == expected_state_id,
-            "Expected state id = {}. Found {}",
-            expected_state_id,
-            state.borrow().get_state_id().get_id()
-        );
-    }
-    // Test an un-handled event
-    {
-        light_hsm.dispatch_into_hsm(LightEvents::TurnOn);
-
-        let state = light_hsm.get_current_state();
-        let state_id = state.borrow().get_state_id();
-        let expected_state_id = StateId::new(LightStates::ON as u16);
-        assert!(
-            state_id == expected_state_id,
-            "Expected state id = {}. Found {}",
-            expected_state_id,
-            state.borrow().get_state_id().get_id()
-        );
-    }
-    // leverage parent (dimmer's) behavior
-    {
-        light_hsm.dispatch_into_hsm(LightEvents::Set(50));
-        let state = light_hsm.get_current_state();
-        let state_id = state.borrow().get_state_id();
-        let expected_state_id = StateId::new(LightStates::ON as u16);
+        let expected_state_id = StateId::new(LightStates::OFF as u16);
         assert!(
             state_id == expected_state_id,
             "Expected state id = {}. Found {}",
@@ -53,6 +25,35 @@ fn main() {
         );
 
         let data = light_hsm.get_light_data();
-        assert_eq!(data.borrow().light_percentage, 50);
+        assert_eq!(data.borrow().light_percentage, 0);
+    }
+    // Cause a no-op, we are already on! - Test an un-handled event
+    {
+        light_hsm.dispatch_into_hsm(LightEvents::TurnOn);
+
+        let state = light_hsm.get_current_state();
+        let state_id = state.borrow().get_state_id();
+        let expected_state_id = StateId::new(LightStates::ON as u16);
+
+        assert!(
+            state_id == expected_state_id,
+            "Expected state id = {}. Found {}",
+            expected_state_id,
+            state.borrow().get_state_id().get_id()
+        );
+    }
+    // Cause a state change via turn off event (by levering parent behavior!)
+    {
+        light_hsm.dispatch_into_hsm(LightEvents::TurnOff);
+
+        let state = light_hsm.get_current_state();
+        let state_id = state.borrow().get_state_id();
+        let expected_state_id = StateId::new(LightStates::OFF as u16);
+        assert!(
+            state_id == expected_state_id,
+            "Expected state id = {}. Found {}",
+            expected_state_id,
+            state.borrow().get_state_id().get_id()
+        );
     }
 }

--- a/example_hsm/src/main.rs
+++ b/example_hsm/src/main.rs
@@ -6,15 +6,15 @@ use light_hsm::{
 };
 
 fn main() {
-    let light_hsm = LightControllerHsm::new();
+    let mut light_hsm = LightControllerHsm::new();
 
-    let starting_state = light_hsm.borrow().get_current_state();
+    let starting_state = light_hsm.get_current_state();
     assert!(starting_state.borrow().get_state_id().get_id().clone() == LightStates::OFF as u16);
 
     {
-        light_hsm.borrow().dispatch_into_hsm(LightEvents::TurnOn);
+        light_hsm.dispatch_into_hsm(LightEvents::TurnOn);
 
-        let state = light_hsm.borrow().get_current_state();
+        let state = light_hsm.get_current_state();
         let state_id = state.borrow().get_state_id();
         let expected_state_id = StateId::new(LightStates::ON as u16);
 
@@ -27,9 +27,9 @@ fn main() {
     }
     // Test an un-handled event
     {
-        light_hsm.borrow().dispatch_into_hsm(LightEvents::TurnOn);
+        light_hsm.dispatch_into_hsm(LightEvents::TurnOn);
 
-        let state = light_hsm.borrow().get_current_state();
+        let state = light_hsm.get_current_state();
         let state_id = state.borrow().get_state_id();
         let expected_state_id = StateId::new(LightStates::ON as u16);
         assert!(
@@ -41,8 +41,8 @@ fn main() {
     }
     // leverage parent (dimmer's) behavior
     {
-        light_hsm.borrow().dispatch_into_hsm(LightEvents::Set(50));
-        let state = light_hsm.borrow().get_current_state();
+        light_hsm.dispatch_into_hsm(LightEvents::Set(50));
+        let state = light_hsm.get_current_state();
         let state_id = state.borrow().get_state_id();
         let expected_state_id = StateId::new(LightStates::ON as u16);
         assert!(
@@ -52,7 +52,7 @@ fn main() {
             state.borrow().get_state_id().get_id()
         );
 
-        let data = light_hsm.borrow().get_light_data();
+        let data = light_hsm.get_light_data();
         assert_eq!(data.borrow().light_percentage, 50);
     }
 }

--- a/rust_hsm/src/events.rs
+++ b/rust_hsm/src/events.rs
@@ -1,5 +1,10 @@
 ///! This file contains the logic behind events that can be used by states
 use core::fmt;
+use std::collections::VecDeque;
+use std::rc::Rc;
+
+pub type StateEventRef = Rc<dyn StateEventsIF>;
+pub type StateEventVec = VecDeque<StateEventRef>;
 
 /// Abstracts common functionality for all state events into the trait.
 /// Makes impl of actual enum's easier.

--- a/rust_hsm/src/state.rs
+++ b/rust_hsm/src/state.rs
@@ -1,7 +1,7 @@
 ///! This file contains the logic for an individual state and how they link together
 use std::{cell::RefCell, rc::Rc};
 
-use crate::{events::StateEventsIF, state_controller_trait::HsmControllerRef};
+use crate::events::StateEventsIF;
 
 #[derive(PartialEq, Clone)]
 pub struct StateId {
@@ -74,10 +74,6 @@ pub trait StateChainOfResponsibility {
         self.get_state_data().get_state_name()
     }
 
-    fn get_hsm(&self) -> HsmControllerRef {
-        self.get_state_data().get_hsm()
-    }
-
     /// Gets the path to root. Including self and root.
     fn get_path_to_root_state(&self) -> Vec<StateId> {
         let mut path_to_root = Vec::<StateId>::new();
@@ -103,22 +99,15 @@ pub struct ComposableStateData {
     // None if there is no parent state (i.e. TOP state)
     state_name: String,
     parent_state: Option<StateRef>,
-    state_machine: HsmControllerRef,
     requested_state_change: Option<StateId>,
 }
 
 impl ComposableStateData {
-    pub fn new(
-        state_id: u16,
-        state_name: String,
-        parent_state: Option<StateRef>,
-        state_machine: HsmControllerRef,
-    ) -> Self {
+    pub fn new(state_id: u16, state_name: String, parent_state: Option<StateRef>) -> Self {
         Self {
             state_id: StateId::new(state_id),
             state_name,
             parent_state,
-            state_machine,
             requested_state_change: None,
         }
     }
@@ -142,10 +131,6 @@ impl ComposableStateData {
         let state_change = self.requested_state_change.clone();
         self.requested_state_change = None;
         state_change
-    }
-
-    pub fn get_hsm(&self) -> HsmControllerRef {
-        self.state_machine.clone()
     }
 
     /// Stores the requested state change.

--- a/rust_hsm/src/state_controller.rs
+++ b/rust_hsm/src/state_controller.rs
@@ -20,6 +20,8 @@ pub struct HSMControllerBase {
 }
 
 impl HSMControllerBase {
+    /// Create an HSM controller.
+    // Highly recommend NOT exposing the HSM beyond your container.
     pub fn new(hsm_name: String) -> HsmControllerRef {
         Rc::new(RefCell::new(HSMControllerBase {
             hsm_name,

--- a/rust_hsm/src/state_controller.rs
+++ b/rust_hsm/src/state_controller.rs
@@ -1,11 +1,10 @@
-use std::{cell::RefCell, rc::Rc};
-
 ///! This file contains the logic for a state engine comprised of many
 ///! composable states
 use crate::{
+    errors::{HSMError, HSMResult},
     events::StateEventsIF,
     state::{StateRef, StatesRefVec},
-    state_controller_trait::{HsmController, HsmControllerRef},
+    state_controller_trait::HsmController,
 };
 
 /// Compose / decorate your hsm controller with this
@@ -22,21 +21,17 @@ pub struct HSMControllerBase {
 impl HSMControllerBase {
     /// Create an HSM controller.
     // Highly recommend NOT exposing the HSM beyond your container.
-    pub fn new(hsm_name: String) -> HsmControllerRef {
-        Rc::new(RefCell::new(HSMControllerBase {
+    pub(crate) fn new(hsm_name: String) -> HSMControllerBase {
+        HSMControllerBase {
             hsm_name,
             states: vec![],
             current_state: None,
             state_change_string: String::new(),
-        }))
+        }
     }
 }
 
 impl HsmController for HSMControllerBase {
-    fn add_state(&mut self, new_state: StateRef) {
-        self.states.push(new_state.clone());
-    }
-
     fn external_dispatch_into_hsm(&mut self, event: &dyn StateEventsIF) {
         // Override for a more custom implementation
         self.handle_event(event)
@@ -69,5 +64,51 @@ impl HsmController for HSMControllerBase {
 
     fn get_hsm_name(&self) -> String {
         self.hsm_name.clone()
+    }
+}
+
+/// Struct encapsulating the process of building an HsmController.
+/// Enforces immutability of the controller as states are added.
+pub struct HsmControllerBuilder {
+    controller_under_construction: HSMControllerBase,
+}
+
+impl HsmControllerBuilder {
+    pub fn new(hsm_name: String) -> HsmControllerBuilder {
+        // let controller = HSMControllerBase {
+        //     hsm_name,
+        //     states: vec![],
+        //     current_state: None,
+        //     state_change_string: String::new(),
+        // };
+        let controller = HSMControllerBase::new(hsm_name);
+
+        HsmControllerBuilder {
+            controller_under_construction: controller,
+        }
+    }
+
+    pub fn add_state(mut self, new_state: StateRef) -> Self {
+        self.controller_under_construction
+            .states
+            .push(new_state.clone());
+        self
+    }
+
+    /// Final step in process
+    pub fn init(mut self, initial_state: StateRef) -> HSMResult<HSMControllerBase> {
+        let initial_state_id = initial_state.borrow().get_state_id();
+        let states = self.controller_under_construction.get_states();
+        if *initial_state_id.get_id() as usize >= states.len() {
+            return Err(HSMError::InvalidStateId(format!(
+                "Initial State with Id {} is not valid. There are only {} states!",
+                *initial_state_id.get_id(),
+                states.len() - 1
+            )));
+        }
+
+        self.controller_under_construction
+            .set_current_state(initial_state);
+        Ok(self.controller_under_construction)
     }
 }

--- a/rust_hsm/src/state_controller_trait.rs
+++ b/rust_hsm/src/state_controller_trait.rs
@@ -25,29 +25,12 @@ pub type HsmControllerRef = Rc<RefCell<dyn HsmController>>;
 /// # Non Trivial functions to implement (even if the trivial ones are done right)
 ///     * external_dispatch_into_hsm: requires an understanding of how your system behaves
 pub trait HsmController {
-    fn init(&mut self, initial_state: StateRef) -> HSMResult<()> {
-        let initial_state_id = initial_state.borrow().get_state_id();
-        let states = self.get_states();
-        if *initial_state_id.get_id() as usize >= states.len() {
-            return Err(HSMError::InvalidStateId(format!(
-                "Initial State with Id {} is not valid. There are only {} states!",
-                *initial_state_id.get_id(),
-                states.len() - 1
-            )));
-        }
-
-        self.set_current_state(initial_state);
-
-        Ok(())
-    }
-
     /// Fire an event external to the HSM into it and see how it gets handled.
     /// If there is complicated threading between consumers and this HSM,
     /// override this function to navigate the ITC between them.
     // fn external_dispatch_into_hsm(&mut self, event: &dyn StateEventsIF);
     fn external_dispatch_into_hsm(&mut self, event: &dyn StateEventsIF);
 
-    fn add_state(&mut self, new_state: StateRef);
     fn get_current_state(&self) -> StateRef;
     fn set_current_state(&mut self, new_current_state: StateRef);
     fn get_states(&self) -> StatesRefVec;

--- a/rust_hsm/src/state_controller_trait.rs
+++ b/rust_hsm/src/state_controller_trait.rs
@@ -6,8 +6,6 @@ use crate::{
 
 use std::{cell::RefCell, rc::Rc};
 
-pub type HsmControllerRef = Rc<RefCell<dyn HsmController>>;
-
 /// The traits required to be a proper HSM controller
 /// Everything is implemented for consumers.
 /// The rest is implemented by HSMControllerBase.

--- a/rust_hsm/src/state_controller_trait.rs
+++ b/rust_hsm/src/state_controller_trait.rs
@@ -1,6 +1,6 @@
 use crate::{
     errors::{HSMError, HSMResult},
-    events::StateEventsIF,
+    events::{StateEventVec, StateEventsIF},
     state::{StateChainOfResponsibility, StateId, StateRef, StatesRefVec},
 };
 
@@ -21,19 +21,19 @@ use std::{cell::RefCell, rc::Rc};
 ///     * get_state_change_string
 ///     * clear_requested_new_state
 /// # Non Trivial functions to implement (even if the trivial ones are done right)
-///     * external_dispatch_into_hsm: requires an understanding of how your system behaves
+///     * dispatch_event: requires an understanding of how your system behaves
 pub trait HsmController {
     /// Fire an event external to the HSM into it and see how it gets handled.
     /// If there is complicated threading between consumers and this HSM,
     /// override this function to navigate the ITC between them.
-    // fn external_dispatch_into_hsm(&mut self, event: &dyn StateEventsIF);
-    fn external_dispatch_into_hsm(&mut self, event: &dyn StateEventsIF);
+    fn dispatch_event(&mut self, event: &dyn StateEventsIF);
 
     fn get_current_state(&self) -> StateRef;
     fn set_current_state(&mut self, new_current_state: StateRef);
     fn get_states(&self) -> StatesRefVec;
     fn get_state_change_string(&mut self) -> &mut String;
     fn get_hsm_name(&self) -> String;
+    fn append_to_follow_up_events(&mut self, new_follow_up_events: &mut StateEventVec);
 
     /// Send an event into the HSM from within the HSM.
     /// i.e. a state fires an event while handling another event
@@ -43,9 +43,7 @@ pub trait HsmController {
         let mut current_state = self.get_current_state();
 
         let hsm_name = self.get_hsm_name();
-
         self.get_state_change_string().clear();
-
         self.get_state_change_string().push_str(
             format!(
                 "{}: {}({}): ",
@@ -56,26 +54,57 @@ pub trait HsmController {
             .as_str(),
         );
 
+        let mut requested_state_change: Option<StateId> = None;
+
         loop {
-            let next_state = current_state.borrow().get_super_state();
-
-            if next_state.is_none() {
-                break;
-            }
-
             let is_handled = current_state.borrow_mut().handle_event(event);
+
+            let local_requested_state_change = current_state
+                .borrow_mut()
+                .get_state_data_mut()
+                .get_and_reset_requested_state_change();
+
+            let nested_change_requested = local_requested_state_change.is_some() && requested_state_change.is_some();
+            assert!(
+                !nested_change_requested,
+                "Requested state change to {} but a change to {} was already requested! Illegal nested state change!",
+                local_requested_state_change.unwrap(),
+                requested_state_change.unwrap()
+            );
+
+            requested_state_change = local_requested_state_change;
 
             if is_handled {
                 // event has been handled!
                 break;
             }
 
-            // See if parent state handles this
+            let next_state = current_state.borrow().get_super_state();
+            if next_state.is_none() {
+                break;
+            }
+
+            // Maybe the parent state handles this
             current_state = next_state.unwrap();
         }
 
+        // Cache the follow up events before we change state
+        // The events will have been set by the chain of handle_events
+        let mut follow_up_events = current_state.borrow_mut().get_and_reset_follow_up_events();
+
         // Check if a state change was requested on state data cache while processing.
-        self.handle_state_change();
+        self.handle_state_change(requested_state_change);
+
+        // At this point, the state has changed
+
+        if let Some(next_event) = follow_up_events.pop_back() {
+            self.handle_event(next_event.as_ref());
+            for follow_up_event in follow_up_events {
+                self.get_current_state()
+                    .borrow_mut()
+                    .dispatch_internally(follow_up_event)
+            }
+        }
     }
 
     fn get_state_name(&self, state_id: &StateId) -> Option<String> {
@@ -117,19 +146,13 @@ pub trait HsmController {
     /// THEN handle start on target.
     /// # NOTE
     /// CHANGE STATES ARE ENQUEUED BY ComposableStateData::submit_state_change_request
-    fn handle_state_change(&mut self) {
-        let requested_state_opt = self
-            .get_current_state()
-            .borrow_mut()
-            .get_state_data_mut()
-            .get_and_reset_requested_state_change();
-
-        if requested_state_opt.is_none() {
+    fn handle_state_change(&mut self, requested_state_change: Option<StateId>) {
+        if requested_state_change.is_none() {
             self.post_handle_event_operations();
             return;
         }
 
-        let is_target_current = requested_state_opt.clone().unwrap().get_id()
+        let is_target_current = requested_state_change.clone().unwrap().get_id()
             == self.get_current_state().borrow().get_state_id().get_id();
 
         // We don't clear requests once completed - requires too much mutable access
@@ -138,7 +161,7 @@ pub trait HsmController {
             self.post_handle_event_operations();
         }
 
-        let requested_state = requested_state_opt.unwrap();
+        let requested_state = requested_state_change.unwrap();
         let target_state_opt = self.get_state_by_id(&self.get_states(), &requested_state);
 
         if target_state_opt.is_none() {


### PR DESCRIPTION
1. Removed refernces to controller within states
2. Implemented internal dispatches of events from states while handling (other) events
    * Was partially implemented by States owning controller references but had to be re-done to remove the reference
    * The events can be chained and the controller will make sure they all get handled (in order)
3. Corrected bheavior when change state was requested by parent state handling an event
    * Before, the controller ignored change state requests if they were not done to the "current" state.
    * Implemented a mechanism that checks if a rqeuest was made every iteration of the handle loop
4. Implemented Builder pattern for HSMControllerBase which is the most effective way to add states. Helps reduce interior mutability requirements.
5. Modified example HSM to match new builder paradigm, request chaining, and changing states while handled by parent state.