### PR TITLE
State Trait Inehrit from StateIF

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,16 +53,16 @@ The controller always has a "current" state, but in the process of handling
 events, you can inform the controller of a state change request.
 
 This is done indirectly, by requesting a state change with the
-`ComposableStateData` held by all states.
+`StateDataDelegate` held by all states.
 
-Specifically, the `submit_state_change_request` API exposed by `ComposableStateData`.
+Specifically, the `submit_state_change_request` API exposed by `StateDataDelegate`.
 
 Here is an example:
 
 ```Rust
 pub struct FakeState {
-    /// All state's that work with the system will need to have a member of type ComposableStateData
-    base_state_data: ComposableStateData,
+    /// All state's that work with the system will need to have a member of type StateDataDelegate
+    base_state_data: StateDataDelegate,
     shared_data: MyCustomDataStructureSharedAcrossAllStates,
 }
 

--- a/example_hsm/src/light_hsm/light_hsm_controller.rs
+++ b/example_hsm/src/light_hsm/light_hsm_controller.rs
@@ -1,5 +1,6 @@
 use rust_hsm::{
-    state::StateRef,
+    errors::HSMResult,
+    state::StateId,
     state_controller::{HSMControllerBase, HsmControllerBuilder},
     state_controller_trait::HsmController,
 };
@@ -11,11 +12,13 @@ use crate::light_hsm::{
     light_state_off::LightStateOff,
     light_state_on::LightStateOn,
     light_state_top::LightStateTop,
+    light_states::LightStates,
 };
 
 pub struct LightControllerHsm {
     hsm: HSMControllerBase,
     /// Again...leaking this is a bad idea. It is only done here for testing/asserting
+    /// Do NOT do this in a real HSM
     pub(crate) _shared_data: LightHsmDataRef,
 }
 
@@ -37,7 +40,7 @@ impl LightControllerHsm {
             .add_state(state_on)
             .add_state(state_off.clone())
             .add_state(state_dimmer.clone())
-            .init(state_dimmer)
+            .init(LightStates::DIMMER as u16)
             .unwrap();
 
         let light_hsm = LightControllerHsm {
@@ -49,11 +52,12 @@ impl LightControllerHsm {
     }
 
     /// Note: exposing the current state is ALSO a really bad idea.
-    pub fn get_current_state(&self) -> StateRef {
+    pub fn get_current_state(&self) -> StateId {
         self.hsm.get_current_state()
     }
 
-    pub fn dispatch_into_hsm(&mut self, event: LightEvents) {
+    pub fn dispatch_into_hsm(&mut self, event: LightEvents) -> HSMResult<()> {
+        // In a real system you would want to translate from HSMResult -> your result
         self.hsm.dispatch_event(&event)
     }
 

--- a/example_hsm/src/light_hsm/light_state_on.rs
+++ b/example_hsm/src/light_hsm/light_state_on.rs
@@ -1,6 +1,8 @@
 use rust_hsm::{
     events::StateEventsIF,
-    state::{ComposableStateData, StateChainOfResponsibility, StateRef},
+    state::{StateIF, StateRef},
+    state_builder::StateBuilder,
+    state_data_delegate::StateDelegateRef,
 };
 
 use crate::{
@@ -9,22 +11,29 @@ use crate::{
 use std::{cell::RefCell, rc::Rc};
 
 pub(crate) struct LightStateOn {
-    state_data: ComposableStateData,
+    state_data: StateDelegateRef,
     shared_data: LightHsmDataRef,
 }
 
 impl LightStateOn {
     pub fn new(parent_state: StateRef, shared_data: LightHsmDataRef) -> Rc<RefCell<Self>> {
-        let state_data = ComposableStateData::new(
+        let state_builder = StateBuilder::new(
             LightStates::ON as u16,
             "LightStateOn".to_string(),
-            Some(parent_state),
+            Some(parent_state.borrow().get_state_data()),
         );
 
-        Rc::new(RefCell::new(Self {
-            state_data,
+        let built_state = Rc::new(RefCell::new(Self {
+            state_data: state_builder.get_delegate(),
             shared_data,
-        }))
+        }));
+
+        state_builder
+            .set_concrete_state(built_state.clone())
+            .validate_build()
+            .expect("Failed to build LightStateOn!");
+
+        built_state
     }
 
     fn handle_toggle(&mut self) -> bool {
@@ -33,13 +42,18 @@ impl LightStateOn {
 
     fn handle_turn_off(&mut self) -> bool {
         // TODO - make a macro that takes state data and calls change state for you!
-        self.state_data
-            .submit_state_change_request(LightStates::OFF as u16);
-        true
+        match self
+            .state_data
+            .borrow_mut()
+            .submit_state_change_request(LightStates::OFF as u16)
+        {
+            Ok(()) => true,
+            Err(_) => false,
+        }
     }
 }
 
-impl StateChainOfResponsibility for LightStateOn {
+impl StateIF for LightStateOn {
     fn handle_event(&mut self, event: &dyn StateEventsIF) -> bool {
         let events: LightEvents = LightEvents::from(event);
         // top returns true for all events
@@ -57,11 +71,7 @@ impl StateChainOfResponsibility for LightStateOn {
         self.shared_data.borrow_mut().turn_on();
     }
 
-    fn get_state_data(&self) -> &ComposableStateData {
-        &self.state_data
-    }
-
-    fn get_state_data_mut(&mut self) -> &mut ComposableStateData {
-        &mut self.state_data
+    fn get_state_data(&self) -> StateDelegateRef {
+        self.state_data.clone()
     }
 }

--- a/example_hsm/src/main.rs
+++ b/example_hsm/src/main.rs
@@ -9,19 +9,21 @@ fn main() {
     let mut light_hsm = LightControllerHsm::new();
 
     let starting_state = light_hsm.get_current_state();
-    assert!(starting_state.borrow().get_state_id().get_id().clone() == LightStates::DIMMER as u16);
+    assert!(starting_state.clone().get_id().to_owned() == LightStates::DIMMER as u16);
 
     // Set the dimmer value that triggers another internal event being fired for OFF
     {
-        light_hsm.dispatch_into_hsm(LightEvents::Set(0));
-        let state = light_hsm.get_current_state();
-        let state_id = state.borrow().get_state_id();
+        light_hsm
+            .dispatch_into_hsm(LightEvents::Set(0))
+            .expect("Error dispatching Set event into HSM");
+
+        let state_id = light_hsm.get_current_state();
         let expected_state_id = StateId::new(LightStates::OFF as u16);
         assert!(
             state_id == expected_state_id,
             "Expected state id = {}. Found {}",
             expected_state_id,
-            state.borrow().get_state_id().get_id()
+            state_id.get_id()
         );
 
         let data = light_hsm.get_light_data();
@@ -29,31 +31,33 @@ fn main() {
     }
     // Cause a no-op, we are already on! - Test an un-handled event
     {
-        light_hsm.dispatch_into_hsm(LightEvents::TurnOn);
+        light_hsm
+            .dispatch_into_hsm(LightEvents::TurnOn)
+            .expect("Error dispatching TurnOn event into hsm");
 
-        let state = light_hsm.get_current_state();
-        let state_id = state.borrow().get_state_id();
+        let state_id = light_hsm.get_current_state();
         let expected_state_id = StateId::new(LightStates::ON as u16);
 
         assert!(
             state_id == expected_state_id,
             "Expected state id = {}. Found {}",
             expected_state_id,
-            state.borrow().get_state_id().get_id()
+            state_id.get_id()
         );
     }
     // Cause a state change via turn off event (by levering parent behavior!)
     {
-        light_hsm.dispatch_into_hsm(LightEvents::TurnOff);
+        light_hsm
+            .dispatch_into_hsm(LightEvents::TurnOff)
+            .expect("Error dispatching TurnOff event into HS<");
 
-        let state = light_hsm.get_current_state();
-        let state_id = state.borrow().get_state_id();
+        let state_id = light_hsm.get_current_state();
         let expected_state_id = StateId::new(LightStates::OFF as u16);
         assert!(
             state_id == expected_state_id,
             "Expected state id = {}. Found {}",
             expected_state_id,
-            state.borrow().get_state_id().get_id()
+            state_id.get_id()
         );
     }
 }

--- a/rust_hsm/src/errors.rs
+++ b/rust_hsm/src/errors.rs
@@ -13,4 +13,10 @@ pub enum HSMError {
     Io(#[from] std::io::Error),
     #[error("Event Not Implemented Error")]
     EventNotImplemented(String),
+    #[error("Delegate Details Never Set. Use builder!")]
+    DelegateDetailsNotSet(),
+    #[error("Concrete StateIF never provided!. Use StateBuilder builder correctly!!")]
+    ConcreteStateNotProvidedToBuilder(),
+    #[error("Controller was never initialized. Make sure to call HsmControllerBuilder  Init before using state-related API's!")]
+    ControllerNotInitialized(),
 }

--- a/rust_hsm/src/events.rs
+++ b/rust_hsm/src/events.rs
@@ -47,6 +47,8 @@ pub struct HsmEvent {
     event_args: Vec<u8>,
 }
 
+/// TODO - maybe encourage the use of protobufs? Users can serialize and de-serialize their
+/// protos from strings as the event args
 impl HsmEvent {
     pub fn new(event_id: u16, event_args: Vec<u8>) -> HsmEvent {
         HsmEvent {

--- a/rust_hsm/src/lib.rs
+++ b/rust_hsm/src/lib.rs
@@ -1,5 +1,7 @@
 pub mod errors;
 pub mod events;
 pub mod state;
+pub mod state_builder;
 pub mod state_controller;
 pub mod state_controller_trait;
+pub mod state_data_delegate;

--- a/rust_hsm/src/state_builder.rs
+++ b/rust_hsm/src/state_builder.rs
@@ -1,0 +1,78 @@
+///! Module encapsulating how states are built
+use crate::{
+    errors::{HSMError, HSMResult},
+    state::StateRef,
+    state_data_delegate::{StateDataDelegate, StateDelegateRef},
+};
+
+/// Breaks build-time circular dependency of States and their delegate.
+/// Meant to be used by consumers as the build their states!
+pub struct StateBuilder {
+    delegate_under_construction: StateDelegateRef,
+    state_under_construction: Option<StateRef>,
+    state_id: u16,
+    state_name: String,
+    parent_delegate: Option<StateDelegateRef>,
+}
+
+impl StateBuilder {
+    /// Breaks the deadlock for the delegate<->state relationship by introducing
+    /// a builder that temporary delegate and None for the current state.
+    /// It will provide you with the delegate to inject into your stateIF child.
+    /// With a created stateIF, inject it back into the builder.
+    /// The builder will manage swapping out the temporary delegate(s) with
+    /// real data now that all data is known.
+    /// Unbeknownst to you as a consumer, your state will not crash if used.
+    pub fn new(
+        state_id: u16,
+        state_name: String,
+        parent_delegate: Option<StateDelegateRef>,
+    ) -> Self {
+        StateBuilder {
+            delegate_under_construction: StateDataDelegate::build_temporary(),
+            state_under_construction: None,
+            state_id,
+            state_name,
+            parent_delegate,
+        }
+    }
+
+    /// Use this API to finish building your state, provide us back your state
+    /// state constructor so all steps can be in 1 chain.
+    pub fn get_delegate(&self) -> StateDelegateRef {
+        self.delegate_under_construction.clone()
+    }
+
+    /// Now that the builder provides a delegate, create your true state with it
+    /// and then provide us the real state
+    pub fn set_concrete_state(mut self, real_state: StateRef) -> Self {
+        let real_delegate = StateDataDelegate::build_real(
+            self.state_id,
+            self.state_name.clone(),
+            real_state.clone(),
+            self.parent_delegate.clone(),
+        );
+
+        real_state
+            .borrow_mut().get_state_data()
+            .borrow_mut().set_details(real_delegate.clone())
+            .expect("Builder failed to set_details. Did you order the building of your state correctly?");
+
+        self.delegate_under_construction = real_delegate;
+        self.state_under_construction = Some(real_state);
+        self
+    }
+
+    /// Validates that the state and its pieces have all been built correctly!
+    pub fn validate_build(&self) -> HSMResult<()> {
+        if self.state_under_construction.is_none() {
+            return Err(HSMError::ConcreteStateNotProvidedToBuilder());
+        }
+
+        self.delegate_under_construction
+            .clone()
+            .borrow()
+            .get_details()?;
+        Ok(())
+    }
+}

--- a/rust_hsm/src/state_controller.rs
+++ b/rust_hsm/src/state_controller.rs
@@ -3,19 +3,19 @@
 use crate::{
     errors::{HSMError, HSMResult},
     events::{StateEventVec, StateEventsIF},
-    state::{StateRef, StatesRefVec},
+    state::{StateChainOfResponsibility, StateChainRef, StateId, StateRef, StatesVec},
     state_controller_trait::HsmController,
 };
 
-use std::collections::VecDeque;
+use std::{cell::RefCell, collections::VecDeque, rc::Rc};
 
 /// Compose / decorate your hsm controller with this
 pub struct HSMControllerBase {
     hsm_name: String,
     /// We own the vector of states, but the states themselves are owned by others
-    states: StatesRefVec,
+    states: StatesVec,
     /// Only ever optional before init
-    current_state: Option<StateRef>,
+    current_state: Option<StateId>,
     /// Used to cache the current known sequence of events
     state_change_string: String,
     follow_up_events_requested: StateEventVec,
@@ -33,37 +33,51 @@ impl HSMControllerBase {
             follow_up_events_requested: VecDeque::new(),
         }
     }
+
+    pub fn get_current_state(&self) -> StateId {
+        self.current_state
+            .clone()
+            .expect("Requested the current state before it was init by the builder!")
+    }
 }
 
 impl HsmController for HSMControllerBase {
-    fn dispatch_event(&mut self, event: &dyn StateEventsIF) {
+    fn dispatch_event(&mut self, event: &dyn StateEventsIF) -> HSMResult<()> {
         // Override for a more custom implementation
         self.handle_event(event)
     }
 
-    fn get_current_state(&self) -> StateRef {
+    fn get_current_state_link(&self) -> HSMResult<StateChainRef> {
         if self.current_state.is_none() {
-            assert!(
-                false,
-                "HSM not initialized! Make sure to call Init before using state-related API's!"
-            )
+            return Err(HSMError::ControllerNotInitialized());
         }
-        self.current_state
-            .clone()
-            .expect("HSM not initialized! Make sure to call Init before using state-related API's!")
-            .clone()
+
+        let is_state = |state_link: StateChainRef| -> bool {
+            state_link
+                .borrow()
+                .is_state(&self.current_state.clone().expect(
+                "This should not be possible, we assert ControllerNotInitialized invariant above.",
+            ))
+        };
+
+        let index = self.states
+            .iter()
+            .position(|state_link| is_state(state_link.clone()) )
+            .expect("Something un-imaginably bad has happened if the current state is not a valid state!");
+        let current_state_link = self.states.get(index).unwrap().clone();
+        Ok(current_state_link)
     }
 
     fn append_to_follow_up_events(&mut self, new_follow_up_events: &mut StateEventVec) {
         self.follow_up_events_requested.append(new_follow_up_events);
     }
 
-    fn set_current_state(&mut self, new_current_state: StateRef) {
+    fn set_current_state(&mut self, new_current_state: StateId) {
         self.current_state = Some(new_current_state)
     }
 
-    fn get_states(&self) -> StatesRefVec {
-        self.states.clone()
+    fn get_states(&self) -> &StatesVec {
+        &self.states
     }
 
     fn get_state_change_string(&mut self) -> &mut String {
@@ -77,6 +91,8 @@ impl HsmController for HSMControllerBase {
 
 /// Struct encapsulating the process of building an HsmController.
 /// Enforces immutability of the controller as states are added.
+/// Effectively the public API to the controller for consumers.
+/// After it is destroyed / init is called, the controller is self-managing
 pub struct HsmControllerBuilder {
     controller_under_construction: HSMControllerBase,
 }
@@ -91,29 +107,31 @@ impl HsmControllerBuilder {
     }
 
     pub fn add_state(mut self, new_state: StateRef) -> Self {
-        self.controller_under_construction
-            .states
-            .push(new_state.clone());
+        let state_chain = Rc::new(RefCell::new(StateChainOfResponsibility::new(
+            new_state.clone(),
+            new_state.borrow().get_state_data(),
+        )));
+        self.controller_under_construction.states.push(state_chain);
         self
     }
 
     /// Final step in process
-    pub fn init(mut self, initial_state: StateRef) -> HSMResult<HSMControllerBase> {
-        let initial_state_id = initial_state.borrow().get_state_id();
+    pub fn init(mut self, initial_state_id: u16) -> HSMResult<HSMControllerBase> {
+        let initial_state_id_struct = StateId::new(initial_state_id);
         let states = self.controller_under_construction.get_states();
 
         states
             .iter()
-            .find(|state| state.borrow().get_state_id() == initial_state_id)
+            .find(|state| state.borrow().is_state(&initial_state_id_struct))
             .ok_or_else(|| {
                 HSMError::InvalidStateId(format!(
                     "Initial State with Id {} is not valid. There are no added states with that id",
-                    *initial_state_id.get_id()
+                    initial_state_id
                 ))
             })?;
 
         self.controller_under_construction
-            .set_current_state(initial_state);
+            .set_current_state(initial_state_id_struct.clone());
         Ok(self.controller_under_construction)
     }
 }

--- a/rust_hsm/src/state_data_delegate.rs
+++ b/rust_hsm/src/state_data_delegate.rs
@@ -1,0 +1,156 @@
+///! Module encapsulating the state data delegate which can be used extensively
+///! throughout the library but is obscured to consumers
+use crate::{
+    errors::{HSMError, HSMResult},
+    events::StateEventRef,
+    state::{StateId, StateRef},
+};
+
+use std::{cell::RefCell, collections::VecDeque, rc::Rc};
+
+pub type StateDelegateRef = Rc<RefCell<StateDataDelegate>>;
+type StateDelegateDetailRef = Rc<RefCell<StateDataDelegateDetail>>;
+
+/// Channel to send commands & info from StateFoo -> Controller while handling.
+/// The HSM backend uses this information to properly handle events.
+/// Helps decouple StateIF and handling of events from sending messages back to the controller!
+pub struct StateDataDelegate {
+    /// Details of the delegate consumers of the library should not be aware of
+    pub(self) details: Option<StateDelegateDetailRef>,
+}
+
+/// Encapsulates all details for what is needed for a true delegate
+pub(crate) struct StateDataDelegateDetail {
+    pub(crate) state_id: StateId,
+    // None if there is no parent state (i.e. TOP state)
+    pub(crate) state_name: String,
+    pub(crate) current_state: StateRef,
+    /// The chain of responsibility from the parent node and up. Disconnected from our node.
+    /// TODO - move this out of the detail?
+    pub(crate) parent_delegate: Option<StateDelegateRef>,
+    pub(crate) requested_state_change: Option<StateId>,
+    pub(crate) follow_up_events_requested: VecDeque<StateEventRef>,
+}
+
+impl StateDataDelegate {
+    /// Stores the requested state change.
+    /// The controller will reap the new value once done with its current processing.
+    /// Afterwards, this value will be reset.
+    /// # Why
+    /// The request cannot be submit directly to the controller.
+    /// Complicated reason that simplifies to: triggering an event in the controller causes
+    /// it to be borrowed mutably.
+    /// Likewise, updating the hsm cache to have a new state requires a mutable borrow.
+    /// If change state was submit to the controller directly,
+    /// the state dispatched to would borrow the controller AGAIN causing a panic.
+    /// Instead, indirectly submit the request to the data cache (even if borrowed it is dropped immediately).
+    /// Then have the controller "reap" the results of the change request once it is done handling
+    /// the event; no extra borrows required.
+    pub fn submit_state_change_request(&mut self, new_state: u16) -> HSMResult<()> {
+        self.get_details()?.borrow_mut().requested_state_change = Some(StateId::new(new_state));
+        Ok(())
+    }
+
+    pub fn dispatch_event_internally(&mut self, event: StateEventRef) -> HSMResult<()> {
+        self.get_details()?
+            .borrow_mut()
+            .follow_up_events_requested
+            .push_back(event);
+        Ok(())
+    }
+
+    /// Build a temporary version of the delegate while a real consumer is still
+    /// instantiating their state!
+    pub(crate) fn build_temporary() -> StateDelegateRef {
+        Rc::new(RefCell::new(StateDataDelegate { details: None }))
+    }
+
+    /// Used by Builder to complete the real delegate when it is possible
+    pub(crate) fn build_real(
+        state_id: u16,
+        state_name: String,
+        current_state: StateRef,
+        parent_delegate: Option<StateDelegateRef>,
+    ) -> StateDelegateRef {
+        // Although the consumer is unaware, we have enough to rebuild the
+        // chain from minimal context without leaking its existence to them.
+        let details =
+            StateDataDelegateDetail::new(state_id, state_name, current_state, parent_delegate);
+
+        Rc::new(RefCell::new(StateDataDelegate {
+            details: Some(details),
+        }))
+    }
+
+    /// Meant to be used by the builder once the true delegate is created
+    pub(crate) fn set_details(&mut self, new_delegate: StateDelegateRef) -> HSMResult<()> {
+        let new_details = new_delegate.borrow_mut().get_details()?;
+        self.details.replace(new_details);
+        Ok(())
+    }
+
+    pub(crate) fn get_details(&self) -> HSMResult<StateDelegateDetailRef> {
+        match self.details.clone() {
+            None => Err(HSMError::DelegateDetailsNotSet()),
+            Some(details) => Ok(details),
+        }
+    }
+}
+
+/// TODO - This might be a very C++/C pImpl approach to the design.
+/// Maybe the crate impls should be brought back to the main delegate?
+/// Why removed from main struct:
+///         cluttered struct impl with functions the user shouldn't even have to know exist.
+///         How is that any different from many pub(crate) fn and only a few pub fn? less clutter??
+/// Even the idea that consumers could get access to the innards is scary though.
+/// Best practice research is required.
+impl StateDataDelegateDetail {
+    pub(crate) fn new(
+        state_id: u16,
+        state_name: String,
+        current_state: StateRef,
+        parent_delegate: Option<StateDelegateRef>,
+    ) -> StateDelegateDetailRef {
+        Rc::new(RefCell::new(StateDataDelegateDetail {
+            state_id: StateId::new(state_id),
+            state_name,
+            current_state,
+            parent_delegate,
+            requested_state_change: None,
+            follow_up_events_requested: VecDeque::new(),
+        }))
+    }
+
+    pub(crate) fn get_state_id(&self) -> StateId {
+        self.state_id.clone()
+    }
+
+    pub(crate) fn get_state_name(&self) -> String {
+        self.state_name.clone()
+    }
+
+    pub(crate) fn get_current_state_trait(&self) -> StateRef {
+        self.current_state.clone()
+    }
+
+    pub(crate) fn get_parent_delegate(&self) -> Option<StateDelegateRef> {
+        self.parent_delegate.clone()
+    }
+
+    /// Retrieves the requested state change by consuming it! Resets the value.
+    /// This ensures the same change state is not accidentally requested twice
+    /// (i.e. if it is not cleared after it is done)
+    pub(crate) fn get_and_reset_requested_state_change(&mut self) -> Option<StateId> {
+        self.requested_state_change.take()
+    }
+
+    /// Retrieves the next event requested for processing by consuming it!
+    /// This ensures the same event is not accidentally performed twice.
+    /// No-op if there are no follow-up / requested events!
+    /// Similar to the data structure API but exposes to controller trait!
+    pub(crate) fn get_and_reset_follow_up_events(&mut self) -> VecDeque<StateEventRef> {
+        let consumed = self.follow_up_events_requested.clone();
+        self.follow_up_events_requested.clear();
+        consumed
+    }
+}

--- a/todo.md
+++ b/todo.md
@@ -9,13 +9,17 @@ Main Aims:
 ## Action Items (AI)
 
 1. [x] Use swap to replace change state request in `get_and_reset_requested_state_change`
-2. [ ] Remove controller from states
+2. [x] Remove controller from states
    1. Kind of gross that it is there right now. Not sure if used.
-3. [ ] Move `requested_state_change` API to `StateChainOfResponsibility` instead of `ComposableStateData`
+3. [ ] Move `requested_state_change` API to `StateChainOfResponsibility` instead of `StateDataDelegate`
    1. Tie it to API, not a specific data structure
 4. [ ] Create a macro called `change_state!(state: &dyn StateChainOfResponsibility)`
    1. so that user's dont have to call it themselves / know how it works.
 5. [ ] Try to remove the `Rc`'s / `RefCell's` if possible.
    1. Now that we know the impl works, try to minimize as much of the "cludge" as possible
 6. [ ] Add actual tests!
-7. [ ] De-couple `StateChainOfResponsibility` from `ComposableStateData` (if possible)
+7. [x] De-couple `StateChainOfResponsibility` from `StateDataDelegate` (if possible)
+8. [ ] Optimize number of borrows that occur
+9. [ ] Convert u8 buffer of `event_args` to a string that is serialized and deserialized
+   1. [ ] Can be integrated with serde
+10. [ ] Remove `get_state_data` from `StateIF` - Not sure possible!

--- a/todo.md
+++ b/todo.md
@@ -23,3 +23,20 @@ Main Aims:
 9. [ ] Convert u8 buffer of `event_args` to a string that is serialized and deserialized
    1. [ ] Can be integrated with serde
 10. [ ] Remove `get_state_data` from `StateIF` - Not sure possible!
+11. Create handler map in HSM controller
+    1. Now that StateIF is less cluttered, try to genericize HSmController
+    2. `HsmController<StateTrait: Rc<RefCell<dyn StateIF>>>`
+       1. Each consumer can derive a new `StateTrait` from StateIF and ass as many handlers as desired!
+       2. As long as they get registered with the handler map!
+    3. Try to de-emphasize there being 1 `HandleEvent` function
+       1. controller's `handle_event(event_id)` can use something like
+       2. `StateTrait::get_evt_handler(event_id) -> Rc<dyn Fn(<serialized data type>) -> bool>`
+12. Deprecate `StateChainOfResponsibility` if possible.
+    1. Play around with giving `HSMController` new members to replace it:
+       1. state_map: `map<StateId, StateTrait`>
+       2. state_chains: `map<StateId, parentStateId>`
+          1. WEhen coupled with the existing states member, we might be able to remove the entire chain!
+       3. Chain mappings can be created during `AddState(stateref, Optional parentStateId)`
+13. Investigate if we can leverage pImpl pattern with TypeErasure. Why:
+    1. To hide the `Rc's` from the consumer!
+    2. They might be internal to the struct doing the TypeErasure, but consumers have r-value


### PR DESCRIPTION
* Simplified the API from consumer -(create)-> State and State -> Controller without consumer being aware.
* Split StateChainOfResponsibility into `StateIF` and `StateChainOfResponsibility`.
    * Consumers are expected to derive from StateIF's but internal to the HSM library, it thinks in-terms of `StateChainOfResponsibility`.
    * `StateIF` and `StateChainOfResponsibility` indirectly communicate via their delegates which get consumed by the controller.
    * Users do NOT interact with `StateChainOfResponsibility`. They interact with the system by deriving from `StateIF` which the controller interacts with when handling events.
    * When moving up the chain of responsibility, the controller uses the current delegate to find the chain for the next state.
* Added more errors for State & Controller Building + Initialization
* Added `StateBuilder` to break the dead-lock of creating a stateIF without leaking gross logic to consumers.
* Renamed StateData to State Delegate as it delegated behavior State<->Controller. It uses pImpl pattern to hide data from consumers and make it easier for the builder.
* Added more todo's
* Added more results and propogation.
* Updated example to use new API's and builders.