### PR TITLE
Break circular rc

### DIFF
--- a/example_hsm/src/light_hsm/light_hsm_controller.rs
+++ b/example_hsm/src/light_hsm/light_hsm_controller.rs
@@ -1,4 +1,4 @@
-use rust_hsm::{errors::HSMResult, state_engine::HSMEngine};
+use rust_hsm::{errors::HSMResult, state_engine::HSM};
 
 use crate::light_hsm::{
     light_events::LightEvents,
@@ -10,10 +10,8 @@ use crate::light_hsm::{
     light_states::LightStates,
 };
 
-use std::rc::Rc;
-
 pub struct LightControllerHsm {
-    engine: Rc<HSMEngine<LightStates, LightEvents>>,
+    hsm: HSM<LightStates, LightEvents>,
     /// Again...leaking this is a bad idea. It is only done here for testing/asserting
     /// Do NOT do this in a real HSM
     pub(crate) _shared_data: LightHsmDataRef,
@@ -23,32 +21,28 @@ impl LightControllerHsm {
     pub fn new(engine_log_level: log::LevelFilter) -> Self {
         let shared_data = LightHsmData::new(0);
 
-        let engine = HSMEngine::new("LightControllerHsm".to_string(), engine_log_level).unwrap();
+        let hsm = HSM::new("LightControllerHsm".to_string(), engine_log_level).unwrap();
 
         let top_state = LightStateTop::new(shared_data.clone());
 
         // dimmer leverage's similar behavior to on in most cases!
         // the non-shared behavior they impl for themselves!
         // Hence on is dimmer's parent.
-        let state_on = LightStateOn::new(shared_data.clone(), HSMEngine::get_delegate(&engine));
-        let state_dimmer =
-            LightStateDimmer::new(shared_data.clone(), HSMEngine::get_delegate(&engine));
-        let state_off = LightStateOff::new(shared_data.clone(), HSMEngine::get_delegate(&engine));
+        let state_on = LightStateOn::new(shared_data.clone(), hsm.get_delegate());
+        let state_dimmer = LightStateDimmer::new(shared_data.clone(), hsm.get_delegate());
+        let state_off = LightStateOff::new(shared_data.clone(), hsm.get_delegate());
 
-        engine.add_state(top_state, LightStates::Top, None).unwrap();
-        engine
-            .add_state(state_on, LightStates::ON, Some(LightStates::Top))
+        hsm.add_state(top_state, LightStates::Top, None).unwrap();
+        hsm.add_state(state_on, LightStates::ON, Some(LightStates::Top))
             .unwrap();
-        engine
-            .add_state(state_off, LightStates::OFF, Some(LightStates::Top))
+        hsm.add_state(state_off, LightStates::OFF, Some(LightStates::Top))
             .unwrap();
-        engine
-            .add_state(state_dimmer, LightStates::DIMMER, Some(LightStates::ON))
+        hsm.add_state(state_dimmer, LightStates::DIMMER, Some(LightStates::ON))
             .unwrap();
-        engine.init(LightStates::DIMMER as u16).unwrap();
+        hsm.init(LightStates::DIMMER as u16).unwrap();
 
         LightControllerHsm {
-            engine,
+            hsm,
             _shared_data: shared_data.clone(),
         }
     }
@@ -56,12 +50,12 @@ impl LightControllerHsm {
     /// Note: exposing the current state is ALSO a really bad idea.
     pub(crate) fn get_current_state(&self) -> LightStates {
         // In a real system you would want to translate from HSMResult -> your result
-        self.engine.get_current_state().unwrap()
+        self.hsm.get_current_state().unwrap()
     }
 
     pub(crate) fn dispatch_into_hsm(&self, event: LightEvents) -> HSMResult<(), LightStates> {
         // In a real system you would want to translate from HSMResult -> your result
-        self.engine.dispatch_event(event)
+        self.hsm.dispatch_event(event)
     }
 
     /// In a real HSM this is a BAD idea. DO NOT LEAK the data

--- a/rust_hsm/src/errors.rs
+++ b/rust_hsm/src/errors.rs
@@ -8,6 +8,8 @@ pub type HSMResult<T, States> = std::result::Result<T, HSMError<States>>;
 pub enum HSMError<StateT> {
     #[error("State {0} with id {1} already added, but is getting added again!")]
     AddDuplicateStateId(StateT, u16),
+    #[error("Delegate upgrade failed! was this function called while the EngineDelegate was being destroyed? Context: {0}")]
+    DelegateUpgradeFail(String),
     #[error("Event Not Implemented Error: {0}")]
     EventNotImplemented(String),
     #[error("StateEngine was never initialized. Make sure to call init before using state-related API's!")]

--- a/rust_hsm/src/examples.rs
+++ b/rust_hsm/src/examples.rs
@@ -2,7 +2,7 @@
 use crate::{
     events::StateEventConstraint,
     state::{StateConstraint, StateIF, StateId},
-    state_engine_delegate::EngineDelegate,
+    state_engine_delegate::WeakDelegate,
 };
 
 use std::cell::RefCell;
@@ -55,11 +55,11 @@ pub struct ExampleStateData {
     pub count_d_handled_true: u16,
     pub count_e_handled_true: u16,
     pub count_f_handled_true: u16,
-    pub delegate: EngineDelegate<ExampleStates, ExampleEvents>,
+    pub delegate: WeakDelegate<ExampleStates, ExampleEvents>,
 }
 
 impl ExampleStateData {
-    pub fn new(delegate: EngineDelegate<ExampleStates, ExampleEvents>) -> RefCell<Self> {
+    pub fn new(delegate: WeakDelegate<ExampleStates, ExampleEvents>) -> RefCell<Self> {
         RefCell::new(Self {
             state_entered: false,
             state_exited: false,
@@ -127,28 +127,28 @@ impl StateEventConstraint for ExampleEvents {}
 // Start of State Impl //
 
 impl Top {
-    pub fn new(delegate: EngineDelegate<ExampleStates, ExampleEvents>) -> Box<Self> {
+    pub fn new(delegate: WeakDelegate<ExampleStates, ExampleEvents>) -> Box<Self> {
         Box::new(Self {
             data: ExampleStateData::new(delegate),
         })
     }
 }
 impl A1Impl {
-    pub fn new(delegate: EngineDelegate<ExampleStates, ExampleEvents>) -> Box<Self> {
+    pub fn new(delegate: WeakDelegate<ExampleStates, ExampleEvents>) -> Box<Self> {
         Box::new(Self {
             data: ExampleStateData::new(delegate),
         })
     }
 }
 impl B1Impl {
-    pub fn new(delegate: EngineDelegate<ExampleStates, ExampleEvents>) -> Box<Self> {
+    pub fn new(delegate: WeakDelegate<ExampleStates, ExampleEvents>) -> Box<Self> {
         Box::new(Self {
             data: ExampleStateData::new(delegate),
         })
     }
 }
 impl A2Impl {
-    pub fn new(delegate: EngineDelegate<ExampleStates, ExampleEvents>) -> Box<Self> {
+    pub fn new(delegate: WeakDelegate<ExampleStates, ExampleEvents>) -> Box<Self> {
         Box::new(Self {
             data: ExampleStateData::new(delegate),
         })

--- a/rust_hsm/src/hsm.rs
+++ b/rust_hsm/src/hsm.rs
@@ -1,8 +1,0 @@
-use crate::{
-    state_engine::HSMEngine,
-    errors::HSMResult
-};
-
-pub struct Hsm {
-
-}

--- a/rust_hsm/src/hsm.rs
+++ b/rust_hsm/src/hsm.rs
@@ -1,0 +1,8 @@
+use crate::{
+    state_engine::HSMEngine,
+    errors::HSMResult
+};
+
+pub struct Hsm {
+
+}

--- a/rust_hsm/src/lib.rs
+++ b/rust_hsm/src/lib.rs
@@ -1,5 +1,7 @@
 pub mod errors;
 pub mod events;
+pub mod examples;
+pub mod hsm;
 pub mod logger;
 pub mod state;
 pub mod state_engine;
@@ -7,7 +9,6 @@ pub mod state_engine_delegate;
 mod state_mapping;
 mod utils;
 
-pub mod examples;
 
 #[cfg(test)]
 pub mod test_utils;

--- a/rust_hsm/src/lib.rs
+++ b/rust_hsm/src/lib.rs
@@ -1,14 +1,12 @@
 pub mod errors;
 pub mod events;
 pub mod examples;
-pub mod hsm;
 pub mod logger;
 pub mod state;
 pub mod state_engine;
 pub mod state_engine_delegate;
 mod state_mapping;
 mod utils;
-
 
 #[cfg(test)]
 pub mod test_utils;

--- a/rust_hsm/src/state.rs
+++ b/rust_hsm/src/state.rs
@@ -2,7 +2,7 @@
 use std::{boxed::Box, fmt::Display, vec::Vec};
 
 use crate::{
-    errors::HSMResult, events::StateEventConstraint, state_engine_delegate::EngineDelegate,
+    errors::HSMResult, events::StateEventConstraint, state_engine_delegate::SharedDelegate,
 };
 
 /// All valid definitions of a 'class' of state's must be StateTypes.
@@ -72,7 +72,7 @@ pub trait StateIF<StateT, EventT: StateEventConstraint> {
     fn change_state_during_handle(
         &self,
         new_state: u16,
-        delegate: EngineDelegate<StateT, EventT>,
+        delegate: SharedDelegate<StateT, EventT>,
     ) -> HSMResult<(), StateT> {
         delegate.change_state(new_state)
     }

--- a/rust_hsm/src/state_engine.rs
+++ b/rust_hsm/src/state_engine.rs
@@ -46,7 +46,7 @@ impl<StateT: StateConstraint, EventT: StateEventConstraint> HSMEngine<StateT, Ev
     /// Create an HSM engine.
     /// Highly recommend NOT exposing the HSMEngine beyond your container.
     /// Will need to be built up after the fact - via the builder!
-    pub fn new(
+    pub (crate) fn new(
         hsm_name: String,
         logger_level: LevelFilter,
     ) -> HSMResult<Rc<HSMEngine<StateT, EventT>>, StateT> {

--- a/rust_hsm/src/state_engine_delegate.rs
+++ b/rust_hsm/src/state_engine_delegate.rs
@@ -1,7 +1,7 @@
 //! Module encapsulating the state data delegate which can be used extensively
 //! throughout the library but is obscured to consumers
 use crate::{errors::HSMResult, events::StateEventConstraint};
-use std::rc::Rc;
+use std::rc::{Rc, Weak};
 
 /// Trait representing a valid object delegating powers of the Engine to others (states).
 /// Allows states to know about the HSM while the HSM knows about the states (indirectly through their trait).
@@ -15,7 +15,27 @@ pub trait EngineDelegateIF<StateT, EventT: StateEventConstraint> {
     fn internal_handle_event(&self, event: EventT) -> HSMResult<(), StateT>;
 }
 
-pub type EngineDelegate<StateT, EventT> = Rc<dyn EngineDelegateIF<StateT, EventT>>;
+// Do not leak around the ability to share a delegate! Could lead to cycles!
+pub type SharedDelegate<StateT, EventT> = Rc<dyn EngineDelegateIF<StateT, EventT>>;
+/// If/when you upgrade the delegates to perform operations, do NOT keep the upgrade!
+/// Doing so will cause memory leaks.
+pub type WeakDelegate<StateT, EventT> = Weak<dyn EngineDelegateIF<StateT, EventT>>;
+
+/// Given a weak delegate, upgrade it for use. Helps prevent accidental memory leaks.
+/// # Args:
+/// 1) Path to your WeakDelegate
+/// 2) lambda of type |rc| -> T (what you want to do with strong type)
+/// 3) Fallback T if the weak could not be promoted to an rc
+#[macro_export]
+macro_rules! use_delegate {
+    ($weak_expr:expr, $lambda:expr, $fallback:expr) => {
+        match $weak_expr.upgrade() {
+            Some(strong) => $lambda(strong),
+            None => $fallback,
+        }
+    };
+}
+pub use use_delegate;
 
 #[cfg(test)]
 pub mod delegate_test_utils {
@@ -35,6 +55,12 @@ pub mod delegate_test_utils {
         pub change_states_requested: RefCell<Vec<u16>>,
         pub internal_events_handled: RefCell<Vec<EventT>>,
         marker: PhantomData<StateT>,
+    }
+
+    impl<StateT, EventT: StateEventConstraint> Default for MockedDelegate<StateT, EventT> {
+        fn default() -> Self {
+            Self::new()
+        }
     }
 
     impl<StateT, EventT: StateEventConstraint> MockedDelegate<StateT, EventT> {

--- a/rust_hsm/src/state_mapping.rs
+++ b/rust_hsm/src/state_mapping.rs
@@ -313,7 +313,7 @@ mod tests {
     }
 
     fn resolve_path_to_id(path: &Vec<StateId>) -> Vec<StateId> {
-        path.iter().map(|state_id| *state_id).collect()
+        path.iter().copied().collect()
     }
 
     #[test]

--- a/rust_hsm/src/test_utils.rs
+++ b/rust_hsm/src/test_utils.rs
@@ -4,13 +4,13 @@ use crate::{
     examples::ExampleStates,
     examples::*,
     state::{StateConstraint, StateIF, StateId},
-    state_engine::HSMEngine,
+    state_engine::HSM,
     state_engine_delegate::delegate_test_utils::MockedDelegate,
 };
 
 use log;
 use log::LevelFilter;
-use std::{cell::RefCell, ops::Add, rc::Rc};
+use std::{cell::RefCell, ops::Add};
 
 pub struct DummyStateStruct<ExampleStates: StateConstraint> {
     state_started: RefCell<bool>,
@@ -55,7 +55,7 @@ impl DummyStateStruct<ExampleStates> {
         Box::new(Self {
             state_started: RefCell::new(false),
             _delegate: MockedDelegate::new(),
-            _num_created: num_states_created_counter.clone(),
+            _num_created: *num_states_created_counter,
         })
     }
 }
@@ -68,22 +68,19 @@ pub(crate) fn cast_id_vector(state_list: &Vec<StateId>) -> Vec<ExampleStates> {
     states
 }
 
-pub fn create_test_hsm() -> Rc<HSMEngine<ExampleStates, ExampleEvents>> {
-    let engine = HSMEngine::new("TestHsm".to_string(), LevelFilter::Info).unwrap();
-    let top = Top::new(HSMEngine::get_delegate(&engine));
-    let a1 = A1Impl::new(HSMEngine::get_delegate(&engine));
-    let b1 = B1Impl::new(HSMEngine::get_delegate(&engine));
-    let a2 = A2Impl::new(HSMEngine::get_delegate(&engine));
+pub fn create_test_hsm() -> HSM<ExampleStates, ExampleEvents> {
+    let hsm = HSM::new("TestHsm".to_string(), LevelFilter::Info).unwrap();
+    let top = Top::new(hsm.get_delegate());
+    let a1 = A1Impl::new(hsm.get_delegate());
+    let b1 = B1Impl::new(hsm.get_delegate());
+    let a2 = A2Impl::new(hsm.get_delegate());
 
-    engine.add_state(top, ExampleStates::Top, None).unwrap();
-    engine
-        .add_state(a1, ExampleStates::LevelA1, Some(ExampleStates::Top))
+    hsm.add_state(top, ExampleStates::Top, None).unwrap();
+    hsm.add_state(a1, ExampleStates::LevelA1, Some(ExampleStates::Top))
         .unwrap();
-    engine
-        .add_state(b1, ExampleStates::LevelB1, Some(ExampleStates::Top))
+    hsm.add_state(b1, ExampleStates::LevelB1, Some(ExampleStates::Top))
         .unwrap();
-    engine
-        .add_state(a2, ExampleStates::LevelA2, Some(ExampleStates::LevelA1))
+    hsm.add_state(a2, ExampleStates::LevelA2, Some(ExampleStates::LevelA1))
         .unwrap();
-    engine
+    hsm
 }

--- a/rust_hsm/src/utils.rs
+++ b/rust_hsm/src/utils.rs
@@ -7,7 +7,6 @@ pub(crate) fn get_state_choice<States: From<u16>>(state_id: &StateId) -> States 
 pub(crate) fn resolve_state_name<States: std::fmt::Display + From<u16>>(
     state_id: &StateId,
 ) -> String {
-    // get_state_choice::<States>(state_id).to_string()
     format!("{}", get_state_choice::<States>(state_id))
 }
 
@@ -27,22 +26,13 @@ pub(crate) use get_function_path;
 // Returns the function name along with its direct owner!
 macro_rules! get_function_name {
     () => {{
-        // let mut name: String = "";
         let path: &'static str = crate::utils::get_function_path!();
         let split_res = path.split_terminator("::").collect::<Vec<&str>>();
-        // println!("{:?}", split_res);
-        // &split_res.join("")
         match split_res.len().checked_sub(2) {
             None => path.to_string(),
             Some(second_last_index) => split_res.split_at(second_last_index).1.join("::")
-            // Some(second_last_index) => {
-                // split_res.split_at(second_last_index).1.join("")
-                // (split_res[second_last_index].to_string() + split_res[second_last_index - 1]).as_str()
-            // }
         }
-        // name
 
-        // split_res.last().unwrap()
     }.to_string()};
 }
 pub(crate) use get_function_name;

--- a/rust_hsm/src/utils.rs
+++ b/rust_hsm/src/utils.rs
@@ -30,10 +30,10 @@ macro_rules! get_function_name {
         let split_res = path.split_terminator("::").collect::<Vec<&str>>();
         match split_res.len().checked_sub(2) {
             None => path.to_string(),
-            Some(second_last_index) => split_res.split_at(second_last_index).1.join("::")
+            Some(second_last_index) => split_res.split_at(second_last_index).1.join("::"),
         }
-
-    }.to_string()};
+    }
+    .to_string()};
 }
 pub(crate) use get_function_name;
 


### PR DESCRIPTION
* Double reference to rc between the engine and states(via the delegate) could lead to memory leaks - circular self references
* Create a container class for the engine the dole's out `Weak<...>` to it rather than `Rc<HSMDelegateIF>`
* Users would need to intentionally make their lives harder by upgrading (and keeping) the `Rc<HSMDelegateIF>` to leak memory.
* TODO - fix the ability to
* Cotainer struct (HSM) acts as passthrough to add/init states.
